### PR TITLE
for resourceLink in GenerateMasterKeyAuthorizationSignature without .toLower() - we get an 'unauthorized' error

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -585,7 +585,7 @@ string GenerateMasterKeyAuthorizationSignature(HttpMethod verb, ResourceType res
 {
     var keyType = "master";
     var tokenVersion = "1.0";
-    var payload = $"{verb.ToString().ToLowerInvariant()}\n{resourceType.ToString().ToLowerInvariant()}\n{resourceLink}\n{date.ToLowerInvariant()}\n\n";
+    var payload = $"{verb.ToString().ToLowerInvariant()}\n{resourceType.ToString().ToLowerInvariant()}\n{resourceLink.ToLowerInvariant()}\n{date.ToLowerInvariant()}\n\n";
 
     var hmacSha256 = new System.Security.Cryptography.HMACSHA256 { Key = Convert.FromBase64String(key) };
     var hashPayload = hmacSha256.ComputeHash(System.Text.Encoding.UTF8.GetBytes(payload));


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* for resourceLink in GenerateMasterKeyAuthorizationSignature without .toLower() - we get an 'unauthorized' error

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
Example e.g. here:
https://stackoverflow.com/a/63679119/1600894

repeatable on this endpoint:
https://learn.microsoft.com/en-us/rest/api/cosmos-db/replace-an-offer
